### PR TITLE
fail if any of the requests fail

### DIFF
--- a/src/commands/enable-security-alerts.js
+++ b/src/commands/enable-security-alerts.js
@@ -1,4 +1,4 @@
-const { getRepos } = require("../lib/repos");
+const { getRepos, processRepos } = require("../lib/repos");
 const delay = require("../lib/delay");
 const octokit = require("../lib/client");
 
@@ -28,26 +28,6 @@ ${error.documentation_url}
     });
 };
 
-const processRepos = async (repositories, apply) => {
-  const promises = [];
-
-  for await (const repository of repositories) {
-    if (repository.archived) {
-      continue;
-    }
-
-    if (apply) {
-      // don't wait
-      const promise = enableSecurityAlertsForRepo(repository);
-      promises.push(promise);
-    } else {
-      console.log(`Would enable for ${repository.html_url}`);
-    }
-  }
-
-  return Promise.all(promises);
-};
-
 const enableSecurityAlerts = async (opts) => {
   if (!opts.apply) {
     process.stdout.write("DRY RUN: ");
@@ -62,7 +42,7 @@ const enableSecurityAlerts = async (opts) => {
 
   try {
     const repos = getRepos(opts.org);
-    await processRepos(repos, opts.apply);
+    await processRepos(repos, enableSecurityAlertsForRepo, opts.apply);
   } catch (err) {
     console.error(err.message);
     process.exit(1);
@@ -71,6 +51,5 @@ const enableSecurityAlerts = async (opts) => {
 
 module.exports = {
   enableSecurityAlertsForRepo,
-  processRepos,
   enableSecurityAlerts,
 };

--- a/src/commands/enable-security-alerts.test.js
+++ b/src/commands/enable-security-alerts.test.js
@@ -1,8 +1,5 @@
 const nock = require("nock");
-const {
-  enableSecurityAlertsForRepo,
-  processRepos,
-} = require("./enable-security-alerts");
+const { enableSecurityAlertsForRepo } = require("./enable-security-alerts");
 
 nock.disableNetConnect();
 
@@ -42,20 +39,6 @@ describe("enableSecurityAlertsForRepo()", () => {
     nockFail();
 
     const promise = enableSecurityAlertsForRepo(repo);
-    return expect(promise).rejects.toThrow(/abuse/);
-  });
-});
-
-describe("processRepos()", () => {
-  test("runs across repositories", () => {
-    nockSuccess();
-    return processRepos([repo], true);
-  });
-
-  test("reflects a failure", () => {
-    nockFail();
-
-    const promise = processRepos([repo], true);
     return expect(promise).rejects.toThrow(/abuse/);
   });
 });

--- a/src/commands/enable-security-alerts.test.js
+++ b/src/commands/enable-security-alerts.test.js
@@ -1,5 +1,8 @@
 const nock = require("nock");
-const { enableSecurityAlertsForRepo } = require("./enable-security-alerts");
+const {
+  enableSecurityAlertsForRepo,
+  processRepos,
+} = require("./enable-security-alerts");
 
 nock.disableNetConnect();
 
@@ -14,6 +17,17 @@ const nockSuccess = () => {
     .reply(204);
 };
 
+const nockFail = () => {
+  // https://developer.github.com/v3/#abuse-rate-limits
+  nock("https://api.github.com")
+    .put(`/repos/${repo.owner.login}/${repo.name}/vulnerability-alerts`)
+    .reply(403, {
+      message:
+        "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.",
+      documentation_url: "https://developer.github.com/v3/#abuse-rate-limits",
+    });
+};
+
 afterEach(nock.cleanAll);
 // https://github.com/nock/nock#memory-issues-with-jest
 afterAll(nock.restore);
@@ -22,5 +36,26 @@ describe("enableSecurityAlertsForRepo()", () => {
   test("enables successfully", () => {
     nockSuccess();
     return enableSecurityAlertsForRepo(repo);
+  });
+
+  test("reflects a failure", () => {
+    nockFail();
+
+    const promise = enableSecurityAlertsForRepo(repo);
+    return expect(promise).rejects.toThrow(/abuse/);
+  });
+});
+
+describe("processRepos()", () => {
+  test("runs across repositories", () => {
+    nockSuccess();
+    return processRepos([repo], true);
+  });
+
+  test("reflects a failure", () => {
+    nockFail();
+
+    const promise = processRepos([repo], true);
+    return expect(promise).rejects.toThrow(/abuse/);
   });
 });

--- a/src/commands/enable-security-fixes.js
+++ b/src/commands/enable-security-fixes.js
@@ -29,18 +29,23 @@ ${error.documentation_url}
 };
 
 const processRepos = async (repositories, apply) => {
+  const promises = [];
+
   for await (const repository of repositories) {
     if (repository.archived) {
       continue;
     }
 
     if (apply) {
-      // don' wait
-      enableSecurityFixesForRepo(repository);
+      // don't wait
+      const promise = enableSecurityFixesForRepo(repository);
+      promises.push(promise);
     } else {
       console.log(`Would enable for ${repository.html_url}`);
     }
   }
+
+  return Promise.all(promises);
 };
 
 const enableSecurityFixes = async (opts) => {
@@ -56,10 +61,16 @@ const enableSecurityFixes = async (opts) => {
   );
 
   const repos = getRepos(opts.org);
-  await processRepos(repos, opts.apply);
+  try {
+    await processRepos(repos, opts.apply);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
 };
 
 module.exports = {
   enableSecurityFixesForRepo,
+  processRepos,
   enableSecurityFixes,
 };

--- a/src/commands/enable-security-fixes.js
+++ b/src/commands/enable-security-fixes.js
@@ -24,6 +24,7 @@ const enableSecurityFixesForRepo = (repository) => {
 ${error.message}
 ${error.documentation_url}
 `);
+      throw error;
     });
 };
 

--- a/src/commands/enable-security-fixes.js
+++ b/src/commands/enable-security-fixes.js
@@ -1,4 +1,4 @@
-const { getRepos } = require("../lib/repos");
+const { getRepos, processRepos } = require("../lib/repos");
 const delay = require("../lib/delay");
 const octokit = require("../lib/client");
 
@@ -28,26 +28,6 @@ ${error.documentation_url}
     });
 };
 
-const processRepos = async (repositories, apply) => {
-  const promises = [];
-
-  for await (const repository of repositories) {
-    if (repository.archived) {
-      continue;
-    }
-
-    if (apply) {
-      // don't wait
-      const promise = enableSecurityFixesForRepo(repository);
-      promises.push(promise);
-    } else {
-      console.log(`Would enable for ${repository.html_url}`);
-    }
-  }
-
-  return Promise.all(promises);
-};
-
 const enableSecurityFixes = async (opts) => {
   if (!opts.apply) {
     process.stdout.write("DRY RUN: ");
@@ -62,7 +42,7 @@ const enableSecurityFixes = async (opts) => {
 
   try {
     const repos = getRepos(opts.org);
-    await processRepos(repos, opts.apply);
+    await processRepos(repos, enableSecurityFixesForRepo, opts.apply);
   } catch (err) {
     console.error(err.message);
     process.exit(1);
@@ -71,6 +51,5 @@ const enableSecurityFixes = async (opts) => {
 
 module.exports = {
   enableSecurityFixesForRepo,
-  processRepos,
   enableSecurityFixes,
 };

--- a/src/commands/enable-security-fixes.js
+++ b/src/commands/enable-security-fixes.js
@@ -60,8 +60,8 @@ const enableSecurityFixes = async (opts) => {
     `... Note that repositories will be listed even if they have automated security fixes enabled already.`
   );
 
-  const repos = getRepos(opts.org);
   try {
+    const repos = getRepos(opts.org);
     await processRepos(repos, opts.apply);
   } catch (err) {
     console.error(err.message);

--- a/src/commands/enable-security-fixes.test.js
+++ b/src/commands/enable-security-fixes.test.js
@@ -1,8 +1,5 @@
 const nock = require("nock");
-const {
-  enableSecurityFixesForRepo,
-  processRepos,
-} = require("./enable-security-fixes");
+const { enableSecurityFixesForRepo } = require("./enable-security-fixes");
 
 nock.disableNetConnect();
 
@@ -42,21 +39,6 @@ describe("enableSecurityFixesForRepo()", () => {
     nockFail();
 
     const promise = enableSecurityFixesForRepo(repo);
-    return expect(promise).rejects.toThrow(/abuse/);
-  });
-});
-
-describe("processRepos()", () => {
-  test("runs across repositories", () => {
-    nockSuccess();
-
-    return processRepos([repo], true);
-  });
-
-  test("reflects a failure", () => {
-    nockFail();
-
-    const promise = processRepos([repo], true);
     return expect(promise).rejects.toThrow(/abuse/);
   });
 });

--- a/src/commands/enable-security-fixes.test.js
+++ b/src/commands/enable-security-fixes.test.js
@@ -23,4 +23,18 @@ describe("enableSecurityFixesForRepo()", () => {
     nockSuccess();
     return enableSecurityFixesForRepo(repo);
   });
+
+  test("reflects a failure", () => {
+    // https://developer.github.com/v3/#abuse-rate-limits
+    nock("https://api.github.com")
+      .put(`/repos/${repo.owner.login}/${repo.name}/automated-security-fixes`)
+      .reply(403, {
+        message:
+          "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.",
+        documentation_url: "https://developer.github.com/v3/#abuse-rate-limits",
+      });
+
+    const promise = enableSecurityFixesForRepo(repo);
+    return expect(promise).rejects.toThrow(/abuse/);
+  });
 });

--- a/src/lib/repos.test.js
+++ b/src/lib/repos.test.js
@@ -1,0 +1,20 @@
+const { processRepos } = require("./repos");
+
+const repo = {
+  name: "test-repo",
+  owner: { login: "test-org" },
+};
+
+describe("processRepos()", () => {
+  test("runs across repositories", () => {
+    const fn = () => Promise.resolve("foo");
+    const promise = processRepos([repo], fn, true);
+    return expect(promise).resolves.toEqual(["foo"]);
+  });
+
+  test("reflects a failure", () => {
+    const fn = () => Promise.reject("foo");
+    const promise = processRepos([repo], fn, true);
+    return expect(promise).rejects.toEqual("foo");
+  });
+});


### PR DESCRIPTION
Fixes #33.

Previously, enabling of security alerts and fixes would print out if there were errors doing so for any given repository, but the overall command would still succeed. This pull request centralizes the logic for applying a command against every repository (`processRepos()`), and bubbles up the error (through a `Promise.all()`) to ensure that the overall command fails if it fails for any repository.