### PR TITLE
Cloud gov maintained

### DIFF
--- a/src/commands/archive.js
+++ b/src/commands/archive.js
@@ -66,7 +66,7 @@ const shouldBeArchived = async (repo, cutoff) => {
   }
   
   // Don't archive cloud.gov repos, these are maintained
-  if(repo.org === "cloud-gov"){
+  if(repo.owner.login === 'cloud-gov'){
     return false;
   }
 

--- a/src/commands/archive.js
+++ b/src/commands/archive.js
@@ -64,6 +64,11 @@ const shouldBeArchived = async (repo, cutoff) => {
   if(maintained) {
     return false;
   }
+  
+  // Don't archive cloud.gov repos, these are maintained
+  if(repo.org === "cloud-gov"){
+    return false;
+  }
 
   // if anything has happened with the repository since the cutoff, skip it
   const recentlyUpdated = await updatedSince(repo, cutoff);


### PR DESCRIPTION
Archiving stale 18F repos makes tons of sense, because we don't want dependency alerting for projects that are not deployed and/or maintained. 

Since cloud.gov is a mature product, we don't have the same needs. For security and compliance, we want to make sure we are getting dependency update alerts.

If there are other orgs that should be opted out as well, we can always refactor this line later to check an array.

This is relevant to: https://github.com/18F/ghad/issues/29 

Thanks @mgwalker for the assist!